### PR TITLE
Relocate page tests KAN-28

### DIFF
--- a/pageTests/Chapter2.test.tsx
+++ b/pageTests/Chapter2.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import Chapter2 from './chapter2';
+import Chapter2 from '../pages/chapter2';
 
 describe('Chapter2', () => {
   it('renders the title, subtitle and details', () => {


### PR DESCRIPTION
- To fix vercel build.
- The problem was that since Vercel runs `npm run build` to create the deployable website, this step takes all the files in `pages` directory to make pages. However, it was failing because the test was also on that directory. Let's put **page** tests in the `pageTests` directory and component tests next to the tested component